### PR TITLE
Add extra_body arg to build_rag and cli to enable passing sampling params

### DIFF
--- a/experiments/t0-001/src/t0_001/cli.py
+++ b/experiments/t0-001/src/t0_001/cli.py
@@ -33,6 +33,7 @@ HELP_TEXT = {
     "host_query": "Host to query.",
     "port_query": "Port to query.",
     "env_file": "Path to the .env file.",
+    "extra_body:": "Extra body to pass to the LLM if using OpenAI as service provider.",
 }
 
 
@@ -351,6 +352,10 @@ def serve_rag(
     ] = DEFAULTS["env_file"],
     host: Annotated[str, typer.Option(help=HELP_TEXT["host_serve"])] = DEFAULTS["host"],
     port: Annotated[int, typer.Option(help=HELP_TEXT["port_serve"])] = DEFAULTS["port"],
+    extra_body: Annotated[
+        str | None,
+        typer.Option(help=HELP_TEXT["extra_body:"]),
+    ] = None,  # TODO: Decide whhether to add this to defaults
 ):
     """
     Run the RAG server.
@@ -382,6 +387,7 @@ def serve_rag(
         system_prompt_path=system_prompt_path,
         host=host,
         port=port,
+        extra_body=extra_body,
     )
 
 
@@ -481,6 +487,10 @@ def evaluate_rag(
         str | None,
         typer.Option(help=HELP_TEXT["env_file"]),
     ] = DEFAULTS["env_file"],
+    extra_body: Annotated[
+        str | None,
+        typer.Option(help=HELP_TEXT["extra_body:"]),
+    ] = None,  # TODO: Decide whether to add this to defaults
 ):
     """
     Evaluate the RAG.
@@ -518,6 +528,7 @@ def evaluate_rag(
         prompt_template_path=prompt_template_path,
         system_prompt_path=system_prompt_path,
         deepseek_r1=deepseek_r1,
+        extra_body=extra_body,
     )
 
 
@@ -615,6 +626,10 @@ def rag_chat(
         str | None,
         typer.Option(help=HELP_TEXT["env_file"]),
     ] = DEFAULTS["env_file"],
+    extra_body: Annotated[
+        str | None,
+        typer.Option(help=HELP_TEXT["extra_body:"]),
+    ] = None,  # TODO: Decide whether to add this to defaults
 ):
     """
     Interact with the RAG model in a command line interface.
@@ -644,4 +659,5 @@ def rag_chat(
         llm_model_name=llm_model_name,
         prompt_template_path=prompt_template_path,
         system_prompt_path=system_prompt_path,
+        extra_body=extra_body,
     )

--- a/experiments/t0-001/src/t0_001/rag/build_rag.py
+++ b/experiments/t0-001/src/t0_001/rag/build_rag.py
@@ -248,6 +248,7 @@ def build_rag(
     tools_kwargs: dict = {},
     prompt_template_path: str | Path | None = None,
     system_prompt_path: str | Path | None = None,
+    extra_body: dict | str | None = None,
 ) -> RAG:
     # obtain the retriever for RAG
     retriever = get_parent_doc_retriever(
@@ -284,7 +285,7 @@ def build_rag(
     elif llm_provider == "openai":
         from t0_001.rag.chat_model import get_openai_chat_model
 
-        llm = get_openai_chat_model(model_name=llm_model_name)
+        llm = get_openai_chat_model(model_name=llm_model_name, extra_body=extra_body)
     else:
         raise ValueError(
             f"Unknown LLM provider: {llm_provider}. Use 'huggingface', 'azure_openai', or 'azure'."

--- a/experiments/t0-001/src/t0_001/rag/chat_interact.py
+++ b/experiments/t0-001/src/t0_001/rag/chat_interact.py
@@ -13,6 +13,7 @@ def run_chat_interact(
     llm_model_name: str = "Qwen/Qwen2.5-1.5B-Instruct",
     prompt_template_path: str | None = None,
     system_prompt_path: str | None = None,
+    extra_body: dict | str | None = None,
 ):
     rag = build_rag(
         conditions_file=conditions_file,
@@ -23,6 +24,7 @@ def run_chat_interact(
         llm_model_name=llm_model_name,
         prompt_template_path=prompt_template_path,
         system_prompt_path=system_prompt_path,
+        extra_body=extra_body,
     )
     user_id = "command_line_chat"
     mode = "query-with-sources"

--- a/experiments/t0-001/src/t0_001/rag/chat_model.py
+++ b/experiments/t0-001/src/t0_001/rag/chat_model.py
@@ -134,10 +134,24 @@ def get_azure_endpoint_chat_model(
 
 def get_openai_chat_model(
     model_name: str,
+    extra_body: dict | str | None = None,
 ) -> BaseChatModel:
     from langchain_openai import ChatOpenAI
 
     logging.info(f"Using OpenAI for model: {model_name}")
+
+    if extra_body is None:
+        extra_body = {}
+    else:
+        import json
+
+        try:
+            extra_body = json.loads(extra_body)
+        except json.JSONDecodeError:
+            logging.error(f"extra_body is not a valid json: {extra_body}")
+            raise
+
+    logging.info(f"Extra body to pass to chat/completions: {extra_body}")
 
     api_key = get_environment_variable("OPENAI_API_KEY", model_name)
     base_url = get_environment_variable("OPENAI_BASE_URL", model_name)
@@ -145,6 +159,7 @@ def get_openai_chat_model(
         model=model_name,
         api_key=api_key,
         base_url=base_url,
+        extra_body=extra_body,
     )
 
     return llm

--- a/experiments/t0-001/src/t0_001/rag/evaluate.py
+++ b/experiments/t0-001/src/t0_001/rag/evaluate.py
@@ -253,6 +253,7 @@ def main(
     prompt_template_path: str | None = None,
     system_prompt_path: str | None = None,
     deepseek_r1: bool = False,
+    extra_body: dict | str | None = None,
 ):
     rag = build_rag(
         conditions_file=conditions_file,
@@ -264,6 +265,7 @@ def main(
         tools=[submit_condition_recommendation],
         prompt_template_path=prompt_template_path,
         system_prompt_path=system_prompt_path,
+        extra_body=extra_body,
     )
 
     evaluate_rag(

--- a/experiments/t0-001/src/t0_001/rag/rag_endpoint.py
+++ b/experiments/t0-001/src/t0_001/rag/rag_endpoint.py
@@ -36,6 +36,7 @@ def main(
     system_prompt_path: str | None = None,
     host: str = "0.0.0.0",
     port: int = 8000,
+    extra_body: dict | str | None = None,
 ):
     rag = build_rag(
         conditions_file=conditions_file,
@@ -46,6 +47,7 @@ def main(
         llm_model_name=llm_model_name,
         prompt_template_path=prompt_template_path,
         system_prompt_path=system_prompt_path,
+        extra_body=extra_body,
     )
     app = create_rag_app(rag)
     uvicorn.run(app, host=host, port=port)


### PR DESCRIPTION
At the moment, the s1 model seems to be much slower vs its qwen2.5 counterpart. e.g. :
- Running `uv run t0-001 evaluate-rag data/synthetic_queries/5bb7345_gpt-4o_10_synthetic_queries.jsonl   --k 10   --db-choice chroma   --llm-provider openai   --llm-model-name Qwen/Qwen2.5-32B-Instruct  --prompt-template-path templates/rag_evaluation_prompt.txt   --system-prompt-path templates/rag_evaluation_system_prompt.txt   --output-file ./evaluate-rag-qwen2.5-32b-k10-chroma.jsonl` completes 10/10 responses within ~10 seconds
- Whereas `uv run t0-001 evaluate-rag data/synthetic_queries/5bb7345_gpt-4o_10_synthetic_queries.jsonl   --k 10   --db-choice chroma   --llm-provider openai   --llm-model-name simplescaling/s1.1-32B  --prompt-template-path templates/rag_evaluation_prompt.txt   --system-prompt-path templates/rag_evaluation_system_prompt.txt   --output-file ./evaluate-rag-s1.1-32b-k10-chroma.jsonl` completes 10/10 responses within ~4 mins.

Default sampling params logged when querying the s1.1 model are:
``SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.05, temperature=0.7, top_p=0.8, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=2048, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None)``
Notably max tokens is 2048 for s1.1 vs 512 for qwen.

- Adjusting this max tokens to 512: `uv run t0-001 evaluate-rag data/synthetic_queries/5bb7345_gpt-4o_10_synthetic_queries.jsonl   --k 10   --db-choice chroma   --llm-provider openai   --llm-model-name simplescaling/s1.1-32B  --prompt-template-path templates/rag_evaluation_prompt.txt   --system-prompt-path templates/rag_evaluation_system_prompt.txt   --output-file ./evaluate-rag-s1.1-32b-k10-chroma.jsonl --extra-body '{"max_tokens":512}'`, completes 10/10 within ~1 min 15s

This PR:
- Adds `extra_body` argument to the `build_rag` function
- Adds this arg to cli and other functions where build_rag is called