### PR TITLE
Add reset chat history option

### DIFF
--- a/experiments/t0-001/pyproject.toml
+++ b/experiments/t0-001/pyproject.toml
@@ -36,7 +36,7 @@ rag = [
     "langchain>=0.3.23",
     "langchain-huggingface>=0.1.2",
     "tiktoken>=0.9.0",
-    "langgraph>=0.3.30",
+    "langgraph>=0.4.1",
     "langchain-openai>=0.3.12",
     "langchain-azure-ai>=0.1.2",
 ]

--- a/experiments/t0-001/src/t0_001/rag/chat_interact.py
+++ b/experiments/t0-001/src/t0_001/rag/chat_interact.py
@@ -77,7 +77,7 @@ async def run_chat_interact(
             continue
 
         if message == "\\clear-history":
-            rag.clear_history(user_id=user_id)
+            response = await rag.aclear_history(thread_id=user_id)
             print("Chat history cleared.")
             continue
 


### PR DESCRIPTION
This PR:
- update langgraph version to include newly added `delete_thread` functions
- use these to clear our chat history
- add `\clear-history` to the rag-chat interface