### PR TITLE
Add endpoint to get thread ids

### DIFF
--- a/experiments/t0-001/src/t0_001/rag/build_rag.py
+++ b/experiments/t0-001/src/t0_001/rag/build_rag.py
@@ -207,6 +207,24 @@ class RAG:
             + [state["question"]],
         }
 
+    def get_thread_ids(self):
+        """
+        Get a list of active thread IDs from the stored memory. The thread IDs
+        are sorted by the last message timestamp such that the most recent
+        thread ID is first in the list.
+        """
+        cptuples = self.memory.list({})
+        thread_ids_and_times = [
+            (i.config["configurable"]["thread_id"], i.checkpoint["ts"])
+            for i in cptuples
+        ]
+
+        def get_latest_time(thread_id):
+            return max(time for tid, time in thread_ids_and_times if tid == thread_id)
+
+        unique_thread_ids = set(thread_id for thread_id, _ in thread_ids_and_times)
+        return sorted(unique_thread_ids, key=get_latest_time, reverse=True)
+
     def get_message_history(self, thread_id: str):
         """
         Get a list of messages from the stored memory for a given thread ID.

--- a/experiments/t0-001/src/t0_001/rag/rag_endpoint.py
+++ b/experiments/t0-001/src/t0_001/rag/rag_endpoint.py
@@ -54,6 +54,10 @@ def create_rag_app(rag: RAG) -> FastAPI:
         else:
             return {"messages": conversation_messages, "thread_id": thread_id}
 
+    @app.get("/get_thread_ids")
+    async def get_thread_ids():
+        return {"thread_ids": rag.get_thread_ids()}
+
     return app
 
 


### PR DESCRIPTION
right now the frontend persists a list of thread ids, but it's really the backend that holds this info - so having a way to get this means that state stays synchronised. same idea as #119, we don't want the frontend to duplicate backend state