### PR TITLE
Fix small logic typo in evaluate

### DIFF
--- a/src/t0_1/rag/evaluate.py
+++ b/src/t0_1/rag/evaluate.py
@@ -247,7 +247,7 @@ async def process_query(
             "rag_message": (
                 response["rag_input_messages"][0].content
                 if conversational
-                else response["messages"][0].content
+                else response["messages"][-2].content
             ),
             "rag_answer": response["messages"][-1].content,
             "rag_tool_calls": response["messages"][-1].additional_kwargs.get(


### PR DESCRIPTION
@rwood-97 This is just a very small issue in the logic for storing the results that I fixed months ago but just realised I forgot to push 

## Fix RAG message indexing in evaluate.py

Changed messages[0] to messages[-2] to correctly retrieve the RAG input message that corresponds to the RAG answer. Using [-2] ensures we get the query immediately preceding the response ([-1]), rather than always getting the first message in the conversation.