### PR TITLE
Fix repeat calls to HF api

### DIFF
--- a/src/t0_1/rag/build_rag.py
+++ b/src/t0_1/rag/build_rag.py
@@ -176,6 +176,7 @@ class RAG:
         self.rerank_llm: LLM | None = rerank_llm
         self.rerank_k: int = rerank_k
         self.seed: int | None = seed
+        self._tokenizer = None
         self.memory: InMemorySaver = InMemorySaver()
         self.reset_graph()
 
@@ -389,16 +390,19 @@ class RAG:
         }
 
     def set_up_tokenizer(self):
-        from transformers import AutoTokenizer
+        if self._tokenizer is None:
+            from transformers import AutoTokenizer
 
-        if self.budget_forcing_tokenizer is not None:
-            tokenizer = AutoTokenizer.from_pretrained(self.budget_forcing_tokenizer)
-        else:
-            tokenizer = AutoTokenizer.from_pretrained(
-                self.budget_forcing_kwargs["model_name"]
-            )
+            if self.budget_forcing_tokenizer is not None:
+                self._tokenizer = AutoTokenizer.from_pretrained(
+                    self.budget_forcing_tokenizer
+                )
+            else:
+                self._tokenizer = AutoTokenizer.from_pretrained(
+                    self.budget_forcing_kwargs["model_name"]
+                )
 
-        return tokenizer
+        return self._tokenizer
 
     def _budget_forcing_invoke(
         self, messages: list, config: RunnableConfig


### PR DESCRIPTION
ATM we get this error when running our evals:
```
2026-02-02 11:21:03 [   ERROR] Error querying RAG: HfHubHTTPError - 429 Client Error: Too Many Requests for url: https://huggingface.co/api/models/TomasLaz/t0-2.5-gemma-3-12b-it (Request ID: Root=1-6980889f-02ae24c44f4b5f285681762c;b9b3b0cc-39d0-4c40-b6e9-f26fba300785)

We had to rate limit you, you hit the quota of 1000 api requests per 5 minutes period. Upgrade to a PRO user or Team/Enterprise organization account (https://hf.co/pricing) to get higher limits. See https://huggingface.co/docs/hub/rate-limits
```

This PR fixes this by setting tokenizer as an attribute vs. reloading each time