### PR TITLE
Apply fix for demographics

### DIFF
--- a/src/t0_1/rag/build_rag.py
+++ b/src/t0_1/rag/build_rag.py
@@ -705,6 +705,7 @@ class RAG:
         )
         cleaned_messages = self._clean_messages_for_context(state["messages"])
         system_content = NHS_RETRIEVER_TOOL_PROMPT + self._build_demographics_snippet(state)
+        logging.info(f"llm_with_retrieve_tool_message={[SystemMessage(system_content)] + cleaned_messages}")
         response = llm_with_retrieve_tool.invoke(
             [SystemMessage(system_content)] + cleaned_messages,
         )
@@ -799,6 +800,7 @@ class RAG:
             + conversation_history
             + [HumanMessage(content="Clinical analysis:\n\n" + t0_output)]
         )
+        logging.info(f"{router_messages=}")
 
         # Write the answer marker so the UI knows where the visible answer starts
         writer((AIMessageChunk("\n<|im_start|>answer\n"), config["metadata"]))
@@ -919,6 +921,7 @@ class RAG:
                 "sources": retriever_response["sources"],
             },
         )
+        logging.info(f"{messages_from_prompt=}")
 
         if self.conversational:
             conversation_messages = [


### PR DESCRIPTION
_What claude broke, he must now fix_

This PR fixes the bug where demographics are dropped in the two new system prompts.
The bug was introduced in #172 where we added a router respond stage to the pipeline.

Here is context from debugging with Claude:
```
Demographics entered by users in the web frontend stopped reaching the LLM that generates the patient-facing response.

What changed to cause it:
Commit bfe050c ("Add chatty refactoring") restructured the conversational graph. Previously, the generate node was the final step — it had demographics in its system prompt and its output went directly to the user. The refactoring split this into two steps:

generate — calls the T0 clinical reasoning model (still has demographics in its prompt)
router_respond — takes T0's reasoning and rewrites it into a friendly patient response using a separate router LLM
The problem: router_respond was built with only ROUTER_RESPONSE_PROMPT as its system prompt, which contains no demographics. So the router model — the one that actually talks to the user — had no idea about the patient's age, sex, etc.

The same issue applies to query_or_respond, the entry node that decides whether to use the retrieval tool or reply directly. Its system prompt (NHS_RETRIEVER_TOOL_PROMPT) also has no demographics, so when it responds without triggering retrieval (e.g. "how old am i"), demographics are completely invisible.

How it's fixed:
Added a helper _build_demographics_snippet() that returns the demographics string from the graph state (or empty string if none provided). This snippet is now appended to the system prompts in three places:

query_or_respond — so direct responses can reference patient demographics
router_respond — so the user-facing response model knows the patient's demographics
arouter_respond — the async version of the same
```